### PR TITLE
Restore typelevelShell attribute

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,5 +53,6 @@
     in
     {
       inherit (devshell) overlay;
+      inherit typelevelShell;
     } // flake-utils.lib.eachSystem systems forSystem;
 }


### PR DESCRIPTION
This isn't part of the flakes output schema and not The Right Way To Do This, but it's the documented way and it broke something yesterday.