### PR TITLE
Make nodejs package configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Extra configuration in `typelevelShell`:
 * `typelevelShell.native.enable`: provide a clang environment for scala-native.  Defaults to `true` in the library shell, and `false` elsewhere.
 * `typelevelShell.native.libraries`: a list of split-output libraries to include (dev output) and link (lib output).  Defaults to `[ pkgs.zlib ]`.
 * `typelevelShell.nodejs.enable`: provide NodeJS and Yarn.  Defaults to `true` in the library shell, and `false` elsewhere.
+* `typelevelShell.nodejs.package`: the package to use for NodeJS.  Defaults to `pkgs.nodejs-16_x`.
 * `typelevelShell.sbtMicrosites.enable`: enables Jekyll support for sbt-microsites.  Defaults to `false`.
 * `typelevelShell.sbtMicrosites.siteDir`: directory with your `Gemfile`, `Gemfile.lock`, and `gemset.nix`.  Run [bundix] to create a gemset.nix, and every time you upgrade Jekyll.
 

--- a/modules/nodejs.nix
+++ b/modules/nodejs.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+let
+  cfg = config.typelevelShell.nodejs;
+in
+{
+  options.typelevelShell.nodejs = {
+    enable = mkEnableOption "Provide nodejs and yarn";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.nodejs-16_x;
+      description = "Package to use for nodejs";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    devshell.packages = [
+      cfg.package
+      pkgs.yarn
+    ];
+  };
+}

--- a/modules/typelevelShell.nix
+++ b/modules/typelevelShell.nix
@@ -5,7 +5,10 @@ let
   cfg = config.typelevelShell;
 in
 {
-  imports = [ ./native.nix ];
+  imports = [
+    ./native.nix
+    ./nodejs.nix
+  ];
 
   options.typelevelShell = {
     jdk = {
@@ -14,8 +17,6 @@ in
         default = pkgs.jdk17;
       };
     };
-
-    nodejs.enable = mkEnableOption "Provide nodejs and yarn";
 
     sbtMicrosites = {
       enable = mkEnableOption "Add support for sbt-microsites";
@@ -53,13 +54,10 @@ in
             ${bold}[versions]${reset}
 
               Java - ${cfg.jdk.package.version}
-          '' + optionalString cfg.nodejs.enable "  Node - ${pkgs.nodejs-16_x.version}\n";
+          '' + optionalString cfg.nodejs.enable "  Node - ${cfg.nodejs.package.version}\n";
 
         devshell.packages = [
           cfg.jdk.package
-        ] ++ optionals cfg.nodejs.enable [
-          pkgs.nodejs-16_x
-          pkgs.yarn
         ];
 
         env = [


### PR DESCRIPTION
I don't know whether `nodejs` is the appropriate name since it includes Yarn.  This whole ecosystem still baffles me.  But this is harmonious with the way the JDK is specified.