### PR TITLE
Use default Node.js package

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Extra configuration in `typelevelShell`:
 * `typelevelShell.native.enable`: provide a clang environment for scala-native.  Defaults to `true` in the library shell, and `false` elsewhere.
 * `typelevelShell.native.libraries`: a list of split-output libraries to include (dev output) and link (lib output).  Defaults to `[ pkgs.zlib ]`.
 * `typelevelShell.nodejs.enable`: provide NodeJS.  Defaults to `true` in the library shell, and `false` elsewhere.
-* `typelevelShell.nodejs.package`: the package to use for NodeJS.  Defaults to `pkgs.nodejs-16_x`.
+* `typelevelShell.nodejs.package`: the package to use for NodeJS.  Defaults to `pkgs.nodejs`.
 * `typelevelShell.sbtMicrosites.enable`: enables Jekyll support for sbt-microsites.  Defaults to `false`.
 * `typelevelShell.sbtMicrosites.siteDir`: directory with your `Gemfile`, `Gemfile.lock`, and `gemset.nix`.  Run [bundix] to create a gemset.nix, and every time you upgrade Jekyll.
 

--- a/modules/nodejs.nix
+++ b/modules/nodejs.nix
@@ -10,7 +10,7 @@ in
 
     package = mkOption {
       type = types.package;
-      default = pkgs.nodejs-16_x;
+      default = pkgs.nodejs;
       description = "Package to use for nodejs";
     };
   };


### PR DESCRIPTION
I think this is fine for most projects. It's easy enough to pin to a specific version with the configuration.