### PR TITLE
LLVM_BIN is a single value, not a path

### DIFF
--- a/modules/native.nix
+++ b/modules/native.nix
@@ -32,7 +32,7 @@ in
       }
       {
         name = "LLVM_BIN";
-        prefix = "${pkgs.clang}/bin";
+        value = "${pkgs.clang}/bin";
       }
     ];
   };


### PR DESCRIPTION
When there's already an `LLVM_BIN` environment variable, we want to overwrite it, not turn it into a colon-delimited path.  Otherwise, `$LLVM_BIN/clang` doesn't point to anything, and it does this:

```
sbt:cats-effect> nativeConfig
[error] 'clang' not found in PATH or via 'LLVM_BIN' environment variable.
[error] Please refer to (http://www.scala-native.org/en/latest/user/setup.html)
[error] (Global / nativeConfig) 'clang' not found in PATH or via 'LLVM_BIN' environment variable.
[error] Please refer to (http://www.scala-native.org/en/latest/user/setup.html)
[error] Total time: 0 s, completed Feb 17, 2023 10:59:46 PM
```