### PR TITLE
Stop publsihing to Cachix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,6 @@ jobs:
       - name: "Install Nix️"
         uses: cachix/install-nix-action@v31
 
-      - name: "Install Cachix️"
-        uses: cachix/cachix-action@v15
-        with:
-          name: typelevel
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
       - name: "Run checks"
         run: nix flake check
 


### PR DESCRIPTION
Rationale:

1. I don't think many people use this cache.
2. The nature of this flake is not to build substantial new artifacts, but to assemble artifacts already in the cache.
3. Binary caches require a lot of trust, and absent significant time savings, shouldn't exist.